### PR TITLE
24 password reset本番環境修正

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -67,6 +67,7 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
 
   # 本番環境のメール設定
+  config.action_mailer.default_url_options = Settings.default_url_options.to_h
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.perform_deliveries = true
   config.action_mailer.delivery_method = :smtp

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -70,13 +70,12 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.perform_deliveries = true
   config.action_mailer.delivery_method = :smtp
-
   config.action_mailer.smtp_settings = {
     port:                 587,
-    address:              'smtp.sendgrid.net',
-    domain:               'www.camphood.net',
-    user_name:            ENV['SENDGRID_USERNAME'],
-    password:             ENV['SENDGRID_PASSWORD'],
+    address:              'smtp.gmail.com',
+    domain:               'smtp.gmail.com',
+    user_name:            Rails.application.credentials.dig(:mailer, :mail_address),
+    password:             Rails.application.credentials.dig(:mailer, :app_password),
     authentication:       'login',
     enable_starttls_auto: true
   }

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,0 +1,3 @@
+default_url_options:
+  host: 'www.camphood.net'
+  protocol: 'https'


### PR DESCRIPTION
- メール送信￥サーバーにSendGridを選定したが、アプリが凍結されたため、Gmailを2段階認証してアプリからメールを送るように修正した。

- 本番環境でパスワードリセットをすると、下記エラーが出た。
```
 FATAL -- : [43d4bae0-2a4d-457f-99f1-3bc3cb4f11da]
2021-12-29T07:23:24.689018+00:00 app[web.1]: [43d4bae0-2a4d-457f-99f1-3bc3cb4f11da] ArgumentError (Missing host to link to! Please provide the :host parameter, set default_url_options[:host], or set :only_path to true):
2021-12-29T07:23:24.689019+00:00 app[web.1]: [43d4bae0-2a4d-457f-99f1-3bc3cb4f11da]
2021-12-29T07:23:24.689019+00:00 app[web.1]: [43d4bae0-2a4d-457f-99f1-3bc3cb4f11da] app/mailers/user_mailer.rb:7:in `reset_password_email'
2021-12-29T07:23:24.689020+00:00 app[web.1]: [43d4bae0-2a4d-457f-99f1-3bc3cb4f11da] app/controllers/password_resets_controller.rb:9:in `create'
2021-12-29T07:23:24.693686+00:00 heroku[router]: at=info method=POST path="/password_resets" host=www.camphood.net request_id=43d4bae0-2a4d-457f-99f1-3bc3cb4f11da fwd="92.203.25.208" dyno=web.1 connect=0ms service=51ms status=500 bytes=1827 protocol=https
```

configにて```set default_url_options[:host]```を設定していなかったためだと思われる。追記済み