### PR TITLE
27 analyticsの導入

### DIFF
--- a/app/assets/stylesheets/map.scss
+++ b/app/assets/stylesheets/map.scss
@@ -73,10 +73,6 @@ ul {
   padding-left :0;
 }
 
-li {
-  list-style: none;
-}
-
 @media screen and (max-width:990px) {
   .results_button {
     font-size: 0.8rem;

--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -7,23 +7,23 @@ class OauthsController < ApplicationController
 
   def callback
     provider = auth_params[:provider]
+    if auth_params[:error].present?
+      redirect_to root_path, warning: t('.cancel')
+      return
+    end
     if (@user = login_from(provider))
       redirect_back_or_to root_path, success: t('.success')
     else
-      begin
-        @user = create_from(provider)
-        reset_session
-        auto_login(@user)
-        redirect_to root_path, success: t('.success')
-      rescue StandardError
-        redirect_to root_path, warning: t('.fail')
-      end
+      @user = create_from(provider)
+      reset_session
+      auto_login(@user)
+      redirect_to root_path, success: t('.success')
     end
   end
 
   private
 
   def auth_params
-    params.permit(:code, :provider)
+    params.permit(:code, :provider, :error)
   end
 end

--- a/app/javascript/js/getplaces.js
+++ b/app/javascript/js/getplaces.js
@@ -116,7 +116,7 @@ function displayResults(results, status, pagination) {
         let content = "【評価:" + rating + "】 " + place.name + " （住所:" + place.vicinity + "） ";
 
       // クリック時にMapにマーカー表示するようにボタンタグを作成
-      resultHTML += "<li>" +
+      resultHTML += "<li style=\"list-style: none;\">" +
                   "<button class=\"results_button\"" +
                   " onclick=\"createMarker(" +
                   "'" + place.name + "'," +

--- a/app/views/campsites/show.html.erb
+++ b/app/views/campsites/show.html.erb
@@ -60,7 +60,7 @@
         </div>
         <div class="col-lg-5">
           <div class="text-center">
-            <%= link_to "この無料キャンプ場に行く！", guidance_campsite_path, class: 'btn btn-warning mt-2 mb-5 px-5' %>
+            <%= link_to "この無料キャンプ場の詳細案内", guidance_campsite_path, class: 'btn btn-warning mt-2 mb-5 px-5' %>
             <%= render 'bookmark_button', campsite: @campsite %>
           <div class="mb-5">
             <%= link_to "https://twitter.com/share?url=#{request.original_url}&hashtags=キャンプ,無料キャンプ場,#{@campsite.prefecture.name}の無料キャンプ場,#{@campsite.name}",

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,15 @@
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
     <%= favicon_link_tag('favicon.ico') %>
     <link rel="apple-touch-icon" sizes="180x180" href="assets/apple-touch-icon.png">
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-VKC8RRF1R2"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-VKC8RRF1R2');
+    </script>
   </head>
 
   <body>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,19 +33,19 @@ Rails.application.configure do
 
   # メーラーデフォルトURL指定
   # config.action_mailer.default_url_options = { host: 'localhost:9292' }
-  config.action_mailer.default_url_options = Settings.default_url_options.to_h
-  # config.action_mailer.delivery_method = :letter_opener_web
-  config.action_mailer.delivery_method = :smtp
+  # config.action_mailer.default_url_options = Settings.default_url_options.to_h
+  config.action_mailer.delivery_method = :letter_opener_web
+  # config.action_mailer.delivery_method = :smtp
 
-  config.action_mailer.smtp_settings = {
-    port:                 587,
-    address:              'smtp.gmail.com',
-    domain:               'smtp.gmail.com',
-    user_name:            Rails.application.credentials.dig(:mailer, :mail_address),
-    password:             Rails.application.credentials.dig(:mailer, :app_password),
-    authentication:       'login',
-    enable_starttls_auto: true
-  }
+  # config.action_mailer.smtp_settings = {
+  #   port:                 587,
+  #   address:              'smtp.gmail.com',
+  #   domain:               'smtp.gmail.com',
+  #   user_name:            Rails.application.credentials.dig(:mailer, :mail_address),
+  #   password:             Rails.application.credentials.dig(:mailer, :app_password),
+  #   authentication:       'login',
+  #   enable_starttls_auto: true
+  # }
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = true

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -53,6 +53,7 @@ ja:
     callback:
       success: "Facebookでログインしました"
       fail: "Facebookでのログインに失敗しました"
+      cancel: "Facebookログインをキャンセルしました"
 
   profiles:
     edit:


### PR DESCRIPTION
- Google Analyticsの導入
- Facebookログイン時、キャンセルするとエラーが発生していた。パラメーターにエラーがあると、トップページへ遷移するよう条件分岐を追加した。
- 開発環境でのメーラーも本番環境同様に設定していたので、```letter-opener```へ変更した。
- ```campsite_show```ページの詳細案内ページへ遷移するボタンの文言の変更。ユーザーからわかりにくいと指摘があったため。（この無料キャンプ場へ行く！→この無料キャンプ場の詳細案内へと変更）